### PR TITLE
fix: add support for custom maven registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,24 @@ jobs:
 
 ## Inputs
 
-| parameter              | description                                                                                                                                        | required | default             |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| dry-run                | Whether to run the action in dry-run mode                                                                                                          | `false`  | false               |
-| artifactory-username   | Username to authenticate against a maven artifactory                                                                                               | `false`  |                     |
-| artifactory-password   | Password to authenticate against a maven artifactory                                                                                               | `false`  |                     |
-| artifactory-match-host | A domain name, host name or base URL to match maven artifactory libraries with (see https://docs.renovatebot.com/configuration-options/#matchhost) | `false`  |                     |
-| docker-username        | Username to authenticate against docker hub                                                                                                        | `false`  |                     |
-| docker-password        | Password to authenticate against docker hub                                                                                                        | `false`  |                     |
-| github-token           | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                              | `false`  | ${{ github.token }} |
-| log-level              | Log level to use for renovate                                                                                                                      | `false`  | info                |
-| npm-token              | NPM token to use for authentication                                                                                                                | `false`  |                     |
-| npm-username           | Username to authenticate against the NPM registry                                                                                                  | `false`  |                     |
-| npm-password           | Password to authenticate against the NPM registry                                                                                                  | `false`  |                     |
-| npm-scope              | Scope of the packages to use the custom NPM authentication (e.g @open-turo)                                                                        | `false`  |                     |
-| npm-registry           | URL of the NPM registry to use the custom authentication for                                                                                       | `false`  |                     |
-| terraform-token        | Token to authenticate against terraform registry                                                                                                   | `false`  |                     |
+| parameter                    | description                                                                                                                                        | required | default             |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
+| dry-run                      | Whether to run the action in dry-run mode                                                                                                          | `false`  | false               |
+| artifactory-username         | Username to authenticate against a maven artifactory                                                                                               | `false`  |                     |
+| artifactory-password         | Password to authenticate against a maven artifactory                                                                                               | `false`  |                     |
+| artifactory-match-host       | A domain name, host name or base URL to match maven artifactory libraries with (see https://docs.renovatebot.com/configuration-options/#matchhost) | `false`  |                     |
+| artifactory-registry-urls    | A comma separate list of extra registry URLs to tell renovate to use to find new versions of packages (e.g a jfrog registry)                       | `false`  |                     |
+| artifactory-package-prefixes | Package prefix to tell renovate to look for dependencies in the artifactory-registry-urls (e.g com.openTuro)                                       | `false`  |                     |
+| docker-username              | Username to authenticate against docker hub                                                                                                        | `false`  |                     |
+| docker-password              | Password to authenticate against docker hub                                                                                                        | `false`  |                     |
+| github-token                 | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                              | `false`  | ${{ github.token }} |
+| log-level                    | Log level to use for renovate                                                                                                                      | `false`  | info                |
+| npm-token                    | NPM token to use for authentication                                                                                                                | `false`  |                     |
+| npm-username                 | Username to authenticate against the NPM registry                                                                                                  | `false`  |                     |
+| npm-password                 | Password to authenticate against the NPM registry                                                                                                  | `false`  |                     |
+| npm-scope                    | Scope of the packages to use the custom NPM authentication (e.g @open-turo)                                                                        | `false`  |                     |
+| npm-registry                 | URL of the NPM registry to use the custom authentication for                                                                                       | `false`  |                     |
+| terraform-token              | Token to authenticate against terraform registry                                                                                                   | `false`  |                     |
 
 ## Runs
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,12 @@ inputs:
   artifactory-match-host:
     required: false
     description: A domain name, host name or base URL to match maven artifactory libraries with (see https://docs.renovatebot.com/configuration-options/#matchhost)
+  artifactory-registry-urls:
+    required: false
+    description: A comma separate list of extra registry URLs to tell renovate to use to find new versions of packages (e.g a jfrog registry)
+  artifactory-package-prefixes:
+    required: false
+    description: Package prefix to tell renovate to look for dependencies in the artifactory-registry-urls (e.g com.openTuro)
   docker-username:
     required: false
     description: Username to authenticate against docker hub
@@ -97,7 +103,9 @@ runs:
             if (
               process.env.RENOVATE_ARTIFACTORY_USERNAME &&
               process.env.RENOVATE_ARTIFACTORY_PASSWORD &&
-              process.env.RENOVATE_ARTIFACTORY_MATCH_HOST
+              process.env.RENOVATE_ARTIFACTORY_MATCH_HOST &&
+              process.env.RENOVATE_ARTIFACTORY_REGISTRY_URLS &&
+              process.env.RENOVATE_ARTIFACTORY_PACKAGE_PREFIXES
             ) {
               return {
                 hostRules: [
@@ -109,7 +117,17 @@ runs:
                   },
                 ],
                 name: "artifactory",
-                config: {},
+                config: {
+                  packageRules: [
+                    {
+                      matchDatasources: ["maven"],
+                      matchPackagePrefixes:
+                        process.env.RENOVATE_ARTIFACTORY_PACKAGE_PREFIXES.split(","),
+                      registryUrls:
+                        process.env.RENOVATE_ARTIFACTORY_REGISTRY_URLS.split(","),
+                    },
+                  ],
+                },
               };
             }
           }
@@ -177,7 +195,13 @@ runs:
             repositories: [`${process.env.RENOVATE_REPOSITORY_NAME}`],
             // Add any extra configuration a provider may need
             ...providers.reduce(
-              (rules, provider) => ({ ...rules, ...provider.config }),
+              (rules, provider) => ({
+                ...rules,
+                ...provider.config,
+                packageRules: (rules.packageRules || []).concat(
+                  ...provider.config.packageRules
+                ),
+              }),
               {}
             ),
           };
@@ -187,7 +211,9 @@ runs:
       env:
         LOG_LEVEL: ${{ inputs.log-level }}
         RENOVATE_ARTIFACTORY_MATCH_HOST: ${{ inputs.artifactory-match-host }}
+        RENOVATE_ARTIFACTORY_PACKAGE_PREFIXES: ${{ inputs.artifactory-package-prefixes }}
         RENOVATE_ARTIFACTORY_PASSWORD: ${{ inputs.artifactory-password }}
+        RENOVATE_ARTIFACTORY_REGISTRY_URLS: ${{ inputs.artifactory-registry-urls }}
         RENOVATE_ARTIFACTORY_USERNAME: ${{ inputs.artifactory-username }}
         RENOVATE_DRY_RUN: ${{ inputs.dry-run }}
         RENOVATE_DOCKERHUB_PASSWORD: ${{ inputs.docker-password }}


### PR DESCRIPTION

**Description**

In order to use gradle for private registries, we have to manually pass the registry URLs and package prefixes that renovatebot should use to look for updates of those libraries. The gradle parser doesn't seem to be able to detect these URLs and ends up failing to find updates for private libraries.

With this setup, we can now configure private registries:

```yaml
artifactory-registry-urls: https://my-registry.jfrog.io/releases
artifactory-package-prefixes: com.openTuro
```

**Changes**

* fix: add support for custom maven registries

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
