### PR TITLE
fix: set gradle properties for artifactory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,10 @@ repos:
       - id: actionlint
         # actionlint doesn't like the uses: ./
         exclude: ci.yaml
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*/action\.yaml$'

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@
 [![Conventional commits](https://img.shields.io/badge/conventional%20commits-1.0.2-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Join us!](https://img.shields.io/badge/Turo-Join%20us%21-593CFB.svg)](https://turo.com/jobs)
 
-GitHub Action: run [renovate bot](https://renovatebot.com) with an opinionated runner configuration. It supports
-configuring it to talk to private registries for:
+<!-- prettier-ignore-start -->
+<!-- action-docs-description source="action.yaml" -->
+## Description
 
-- Artifactory
-- Docker
-- NPM
-- Terraform
+GitHub Action that runs renovatebot with a very opinionated runner configuration.  It supports configuring it to talk to private registries for Artifactory, Docker, NPM and Terraform.
+<!-- action-docs-description source="action.yaml" -->
+## Description
+
+GitHub Action that publishes a new release.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -29,32 +33,72 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
-| parameter                    | description                                                                                                                                        | required | default             |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| dry-run                      | Whether to run the action in dry-run mode                                                                                                          | `false`  | `false`             |
-| checkout-repo                | Perform checkout as first step of action                                                                                                           | `false`  | `true`              |
-| artifactory-username         | Username to authenticate against a maven artifactory                                                                                               | `false`  |                     |
-| artifactory-password         | Password to authenticate against a maven artifactory                                                                                               | `false`  |                     |
-| artifactory-match-host       | A domain name, host name or base URL to match maven artifactory libraries with (see https://docs.renovatebot.com/configuration-options/#matchhost) | `false`  |                     |
-| artifactory-registry-urls    | A comma separate list of extra registry URLs to tell renovate to use to find new versions of packages (e.g a jfrog registry)                       | `false`  |                     |
-| artifactory-package-prefixes | Package prefix to tell renovate to look for dependencies in the artifactory-registry-urls (e.g com.openTuro)                                       | `false`  |                     |
-| docker-username              | Username to authenticate against docker hub                                                                                                        | `false`  |                     |
-| docker-password              | Password to authenticate against docker hub                                                                                                        | `false`  |                     |
-| github-token                 | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                              | `false`  | ${{ github.token }} |
-| git-ignored-authors          | Additional Git authors which are ignored by Renovate. Must conform to RFC5322                                                                      | `false`  | []                  |
-| log-level                    | Log level to use for renovate                                                                                                                      | `false`  | info                |
-| npm-token                    | NPM token to use for authentication                                                                                                                | `false`  |                     |
-| npm-username                 | Username to authenticate against the NPM registry                                                                                                  | `false`  |                     |
-| npm-password                 | Password to authenticate against the NPM registry                                                                                                  | `false`  |                     |
-| npm-scope                    | Scope of the packages to use the custom NPM authentication (e.g @open-turo)                                                                        | `false`  |                     |
-| npm-registry                 | URL of the NPM registry to use the custom authentication for                                                                                       | `false`  |                     |
-| terraform-token              | Token to authenticate against terraform registry                                                                                                   | `false`  |                     |
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `dry-run` | <p>Whether to run the action in dry-run mode</p> | `false` | `""` |
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `artifactory-username` | <p>Username to authenticate against a maven artifactory</p> | `false` | `""` |
+| `artifactory-password` | <p>Password to authenticate against a maven artifactory</p> | `false` | `""` |
+| `artifactory-username-property-name` | <p>Name of the gradle property to use for the artifactory username</p> | `false` | `artifactoryUsername` |
+| `artifactory-password-property-name` | <p>Name of the gradle property to use for the artifactory password</p> | `false` | `artifactoryAuthToken` |
+| `artifactory-match-host` | <p>A domain name, host name or base URL to match maven artifactory libraries with (see https://docs.renovatebot.com/configuration-options/#matchhost)</p> | `false` | `""` |
+| `artifactory-registry-urls` | <p>A comma separate list of extra registry URLs to tell renovate to use to find new versions of packages (e.g a jfrog registry)</p> | `false` | `""` |
+| `artifactory-package-prefixes` | <p>Package prefix to tell renovate to look for dependencies in the artifactory-registry-urls (e.g com.openTuro)</p> | `false` | `""` |
+| `docker-username` | <p>Username to authenticate against docker hub</p> | `false` | `""` |
+| `docker-password` | <p>Password to authenticate against docker hub</p> | `false` | `""` |
+| `github-token` | <p>GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `${{ github.token }}` |
+| `git-ignored-authors` | <p>Additional Git authors which are ignored by Renovate. Must conform to RFC5322</p> | `false` | `[]` |
+| `log-level` | <p>Log level to use for renovate</p> | `false` | `info` |
+| `npm-token` | <p>NPM token to use for authentication</p> | `false` | `""` |
+| `npm-username` | <p>Username to authenticate against the NPM registry</p> | `false` | `""` |
+| `npm-password` | <p>Password to authenticate against the NPM registry</p> | `false` | `""` |
+| `npm-scope` | <p>Scope of the packages to use the custom NPM authentication (e.g @open-turo)</p> | `false` | `""` |
+| `npm-registry` | <p>URL of the NPM registry to use the custom authentication for</p> | `false` | `""` |
+| `terraform-token` | <p>Token to authenticate against terraform registry</p> | `false` | `""` |
+<!-- action-docs-inputs source="action.yaml" -->
+## Inputs
 
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| checkout-fetch-depth | The number of commits to fetch. 0 indicates all history for all branches and tags | `false` | 0 |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
+| docker-flavor | Docker flavor to use for docker metadata | `false` | latest=false  |
+| dockerhub-user | username for dockerhub | `false` |  |
+| dockerhub-password | password for dockerhub | `false` |  |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
+| dry-run | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false` | false |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+<!-- action-docs-inputs -->
+<!-- action-docs-outputs -->
+## Outputs
+
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+<!-- action-docs-outputs source="action.yaml" -->
+
+<!-- action-docs-outputs source="action.yaml" -->
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs source="action.yaml" -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs source="action.yaml" -->
+<!-- action-docs-usage source="action.yaml"  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
 
 ## Development
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,7 @@
 name: GitHub Action Renovatebot
-description: GitHub Action that runs renovatebot with a very opinionated runner configuration
+description:
+  GitHub Action that runs renovatebot with a very opinionated runner configuration.  It supports
+  configuring it to talk to private registries for Artifactory, Docker, NPM and Terraform.
 inputs:
   dry-run:
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,14 @@ inputs:
   artifactory-password:
     required: false
     description: Password to authenticate against a maven artifactory
+  artifactory-username-property-name:
+    required: false
+    description: Name of the gradle property to use for the artifactory username
+    default: artifactoryUsername
+  artifactory-password-property-name:
+    required: false
+    description: Name of the gradle property to use for the artifactory password
+    default: artifactoryAuthToken
   artifactory-match-host:
     required: false
     description: A domain name, host name or base URL to match maven artifactory libraries with (see https://docs.renovatebot.com/configuration-options/#matchhost)
@@ -72,8 +80,10 @@ runs:
         RENOVATE_ARTIFACTORY_MATCH_HOST: ${{ inputs.artifactory-match-host }}
         RENOVATE_ARTIFACTORY_PACKAGE_PREFIXES: ${{ inputs.artifactory-package-prefixes }}
         RENOVATE_ARTIFACTORY_PASSWORD: ${{ inputs.artifactory-password }}
+        RENOVATE_ARTIFACTORY_PASSWORD_PROPERTY_NAME: ${{ inputs.artifactory-password-property-name }}
         RENOVATE_ARTIFACTORY_REGISTRY_URLS: ${{ inputs.artifactory-registry-urls }}
         RENOVATE_ARTIFACTORY_USERNAME: ${{ inputs.artifactory-username }}
+        RENOVATE_ARTIFACTORY_USERNAME_PROPERTY_NAME: ${{ inputs.artifactory-username-property-name }}
         RENOVATE_DRY_RUN: ${{ inputs.dry-run }}
         RENOVATE_DOCKERHUB_PASSWORD: ${{ inputs.docker-password }}
         RENOVATE_DOCKERHUB_USERNAME: ${{ inputs.docker-username }}

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -38,11 +38,13 @@ function configureNpm() {
  */
 function configureArtifactory() {
   if (
-    process.env.RENOVATE_ARTIFACTORY_USERNAME &&
-    process.env.RENOVATE_ARTIFACTORY_PASSWORD &&
     process.env.RENOVATE_ARTIFACTORY_MATCH_HOST &&
+    process.env.RENOVATE_ARTIFACTORY_PACKAGE_PREFIXES &&
+    process.env.RENOVATE_ARTIFACTORY_PASSWORD &&
+    process.env.RENOVATE_ARTIFACTORY_PASSWORD_PROPERTY_NAME &&
     process.env.RENOVATE_ARTIFACTORY_REGISTRY_URLS &&
-    process.env.RENOVATE_ARTIFACTORY_PACKAGE_PREFIXES
+    process.env.RENOVATE_ARTIFACTORY_USERNAME &&
+    process.env.RENOVATE_ARTIFACTORY_USERNAME_PROPERTY_NAME
   ) {
     return {
       hostRules: [
@@ -55,6 +57,16 @@ function configureArtifactory() {
       ],
       name: "artifactory",
       config: {
+        secrets: {
+          ARTIFACTORY_PASSWORD: process.env.RENOVATE_ARTIFACTORY_PASSWORD,
+          ARTIFACTORY_USERNAME: process.env.RENOVATE_ARTIFACTORY_USERNAME,
+        },
+        customEnvVariables: {
+          [`ORG_GRADLE_PROJECT_${process.env.RENOVATE_ARTIFACTORY_USERNAME_PROPERTY_NAME}`]:
+            "{{ secrets.ARTIFACTORY_USERNAME }}",
+          [`ORG_GRADLE_PROJECT_${process.env.RENOVATE_ARTIFACTORY_PASSWORD_PROPERTY_NAME}`]:
+            "{{ secrets.ARTIFACTORY_PASSWORD }}",
+        },
         packageRules: [
           {
             matchDatasources: ["maven"],

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -s "${i}""
+  npx action-docs@2 --no-banner -s "${i}" -u "${readme_file}"
+done


### PR DESCRIPTION

**Description**

In some JVM repositories we were getting authentication errors when renovatebot is running. It happens on Java 8 based projects (with some old gradle versions), where gradle can't determine the artifactory properties.

This PR updates the renovateconfig to set as gradle properties via env vars the artifactory token and password when specified.

This has been tested in some internal repos and it works fine

**Changes**

* fix: set gradle properties for artifactory

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
