### PR TITLE
Ensure NPM auth works ok with latest renovatebot

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -4,13 +4,7 @@
  * that authenticates against the same registry for the specified scope.
  */
 function configureNpm() {
-  if (
-    process.env.RENOVATE_NPM_USERNAME &&
-    process.env.RENOVATE_NPM_PASSWORD &&
-    process.env.RENOVATE_NPM_AUTH_TOKEN &&
-    process.env.RENOVATE_NPM_REGISTRY &&
-    process.env.RENOVATE_NPM_SCOPE
-  ) {
+  if (process.env.RENOVATE_NPM_USERNAME && process.env.RENOVATE_NPM_PASSWORD) {
     return {
       hostRules: [
         {
@@ -21,6 +15,16 @@ function configureNpm() {
         },
       ],
       name: "npm",
+    };
+  }
+  if (
+    process.env.RENOVATE_NPM_AUTH_TOKEN &&
+    process.env.RENOVATE_NPM_REGISTRY &&
+    process.env.RENOVATE_NPM_SCOPE
+  ) {
+    return {
+      hostRules: [],
+      name: "npmrc",
       config: {
         npmrc: [
           `${process.env.RENOVATE_NPM_SCOPE}:registry=${process.env.RENOVATE_NPM_REGISTRY}`,

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -15,7 +15,7 @@ function configureNpm() {
       hostRules: [
         {
           hostType: "npm",
-          matchHost: process.env.RENOVATE_NPM_HOST,
+          matchHost: process.env.RENOVATE_NPM_REGISTRY,
           username: process.env.RENOVATE_NPM_USERNAME,
           password: process.env.RENOVATE_NPM_PASSWORD,
         },


### PR DESCRIPTION

**Description**

We recently updated renovate to the latest version and as part of this, setting both npm auth as host rule + the custom npmrc config was producing some issues, as it would give preference the user + password config, and for some registries like Jfrog this doesn't work.

This PR splits the logic so that if username and password are set, we use the host rules (optionally with the passed registry).

**Changes**

* fix: use npm registry for npm match hosts
* fix: don't enable both npm providers at the same time

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
