### PR TITLE
fix(docker): only use dockerhub creds for dockerhub

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -121,6 +121,7 @@ function configureDocker() {
       hostRules: [
         {
           hostType: "docker",
+          hostname: "index.docker.io",
           username: process.env.RENOVATE_DOCKERHUB_USERNAME,
           password: process.env.RENOVATE_DOCKERHUB_PASSWORD,
         },


### PR DESCRIPTION

**Description**

The current config is using the user + password auth for any docker host, failing to check dependencies anonuymously in other registries like ghcr.

This should fix that.

**Changes**

- fix(docker): only use dockerhub creds for dockerhub

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
