### PR TITLE
fix: stop registering artifactory username as a renovate secret

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -64,11 +64,10 @@ function configureArtifactory() {
       config: {
         secrets: {
           ARTIFACTORY_PASSWORD: process.env.RENOVATE_ARTIFACTORY_PASSWORD,
-          ARTIFACTORY_USERNAME: process.env.RENOVATE_ARTIFACTORY_USERNAME,
         },
         customEnvVariables: {
           [`ORG_GRADLE_PROJECT_${process.env.RENOVATE_ARTIFACTORY_USERNAME_PROPERTY_NAME}`]:
-            "{{ secrets.ARTIFACTORY_USERNAME }}",
+            process.env.RENOVATE_ARTIFACTORY_USERNAME,
           [`ORG_GRADLE_PROJECT_${process.env.RENOVATE_ARTIFACTORY_PASSWORD_PROPERTY_NAME}`]:
             "{{ secrets.ARTIFACTORY_PASSWORD }}",
         },


### PR DESCRIPTION
## Summary

- Renovate was aborting downstream repos with `config-secrets-exposed` at the `compileCommitMessage` step, blocking all dependency-update PRs.
- Root cause: `configureArtifactory()` registered the Artifactory **username** (a non-secret service account identifier) in Renovate's `config.secrets`. Renovate substring-scans every secret value against generated commit messages; the username collided with `@turo/...` package-name fragments and triggered a false-positive abort.
- Fix: remove `ARTIFACTORY_USERNAME` from `secrets` and inject it directly into `customEnvVariables` from the env var. Password is unchanged — still in `secrets`, still injected via `{{ secrets.ARTIFACTORY_PASSWORD }}`.

Ticket: [DEVEX-957](https://team-turo.atlassian.net/browse/DEVEX-957)

## Test plan

- [x] Local sanity check: required `renovate-config.js` with test env vars, confirmed `secrets` contains only `ARTIFACTORY_PASSWORD` and `customEnvVariables.ORG_GRADLE_PROJECT_artifactoryUsername` resolves to the literal username value instead of `{{ secrets.ARTIFACTORY_USERNAME }}`.
- [x] E2E: pin a consumer repo's `update-dependencies` workflow to this branch (`open-turo/action-renovate@f/DEVEX-957_fix_config_secrets_exposed`), dispatch with `log-level: debug`, confirm no `config-secrets-exposed` abort and that update PRs get created.