### PR TITLE
fix: pass NPM_AUTH_TOKEN as customEnvVariable for Yarn 4 repos

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -32,6 +32,12 @@ function configureNpm() {
           `${process.env.RENOVATE_NPM_REGISTRY}:_auth=${process.env.RENOVATE_NPM_AUTH_TOKEN}`,
           `${process.env.RENOVATE_NPM_REGISTRY}:always-auth=true`,
         ].join("\n"),
+        secrets: {
+          NPM_AUTH_TOKEN: process.env.RENOVATE_NPM_AUTH_TOKEN,
+        },
+        customEnvVariables: {
+          NPM_AUTH_TOKEN: "{{ secrets.NPM_AUTH_TOKEN }}",
+        },
       },
     };
   }


### PR DESCRIPTION
## Summary
- Yarn 4+ repos use `.yarnrc.yml` which expects `${NPM_AUTH_TOKEN}` as an environment variable
- Renovate's `configureNpm()` token-based auth branch was not passing this through, causing artifact update failures
- Added `NPM_AUTH_TOKEN` to `secrets` (for log redaction) and `customEnvVariables` (for Yarn env resolution)

## Test plan
- [ ] Verify Renovate can successfully update `yarn.lock` artifacts in Yarn 4 repos
- [ ] Confirm no regression for npm-based repos that don't use Yarn

🤖 Generated with [Claude Code](https://claude.com/claude-code)